### PR TITLE
Corrected "collections" link to plural

### DIFF
--- a/views/public/sitemap/show.php
+++ b/views/public/sitemap/show.php
@@ -18,7 +18,7 @@ foreach($collections as $collection) {
         'label'      => metadata($collection,array('Dublin Core','Title')),
         'route'      => 'id',
         'action'     => 'show',
-        'controller' => 'collection',
+        'controller' => 'collections',
         'params'     => array('id' => $collection->id)
     ));
     //    print_r($page);


### PR DESCRIPTION
Google Webmaster tools was rejecting most URLs in my sitemap. On closer inspection this view was generating the URL /collection/ rather than /collections/ - this one character fix corrects this.
