### PR TITLE
Fixed base class name

### DIFF
--- a/SitemapPlugin.php
+++ b/SitemapPlugin.php
@@ -12,7 +12,7 @@
  * 
  * @package Sitemap
  */
-class SitemapPlugin extends Omeka_plugin_AbstractPlugin
+class SitemapPlugin extends Omeka_Plugin_AbstractPlugin
 {
     public function __toString() 
     {


### PR DESCRIPTION
Hi all,

Addresses a class not found exception in this plugin.  The base class "Omeka_plugin_AbstractPlugin" should be written case-sensitively as "Omeka_Plugin_AbstractPlugin." 

Best,
Kate